### PR TITLE
Change RxSwift dependency to be `>= 4.0` instead of `~> 4.0`

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" ~> 4.0
+github "ReactiveX/RxSwift" >= 4.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "4.1.2"
+github "ReactiveX/RxSwift" "4.2.0"


### PR DESCRIPTION
#trivial (I think)

Hi there. I'm trying to use this project, but the `swift` requirement (inherited from `RxSwift`, I believe) is too low. I've simply updated the version requirement here to be `>= 4.0` instead of `~> 4.0`. Maybe this isn't the right solution. Let me know how you might want to approach this.

Thanks.