### PR TITLE
Remove usage of deprecated Variable

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "4.3.1"
+github "ReactiveX/RxSwift" "4.4.0"

--- a/ExampleApp/ExampleApp.xcodeproj/project.pbxproj
+++ b/ExampleApp/ExampleApp.xcodeproj/project.pbxproj
@@ -173,12 +173,14 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ExampleApp/Pods-ExampleApp-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/RxAtomic/RxAtomic.framework",
 				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwiftUtilities/RxSwiftUtilities.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxAtomic.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwiftUtilities.framework",

--- a/ExampleApp/Podfile.lock
+++ b/ExampleApp/Podfile.lock
@@ -1,16 +1,19 @@
 PODS:
-  - RxCocoa (4.1.2):
+  - RxAtomic (4.4.0)
+  - RxCocoa (4.4.0):
     - RxSwift (~> 4.0)
-  - RxSwift (4.1.2)
+  - RxSwift (4.4.0):
+    - RxAtomic (~> 4.4)
   - RxSwiftUtilities (2.1.0):
-    - RxCocoa (~> 4.0)
-    - RxSwift (~> 4.0)
+    - RxCocoa (~> 4.4)
+    - RxSwift (~> 4.4)
 
 DEPENDENCIES:
   - RxSwiftUtilities (from `../`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
+    - RxAtomic
     - RxCocoa
     - RxSwift
 
@@ -19,9 +22,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  RxCocoa: d88ba0f1f6abf040011a9eb4b539324fc426843a
-  RxSwift: e49536837d9901277638493ea537394d4b55f570
-  RxSwiftUtilities: 5077565befe5a96bc45f846887562dd3a4faa73d
+  RxAtomic: eacf60db868c96bfd63320e28619fe29c179656f
+  RxCocoa: df63ebf7b9a70d6b4eeea407ed5dd4efc8979749
+  RxSwift: 5976ecd04fc2fefd648827c23de5e11157faa973
+  RxSwiftUtilities: 01034c5ba9ea6b3910458b46f60eff9eb66103f9
 
 PODFILE CHECKSUM: 76bf4791be77375ab3f65b32b122237d1e9eaf79
 

--- a/RxSwiftUtilities.podspec
+++ b/RxSwiftUtilities.podspec
@@ -8,7 +8,7 @@ Helpful classes and extensions for RxSwift which don't belong in RxSwift core.
   s.homepage     = "https://github.com/RxSwiftCommunity/RxSwiftUtilities"
   s.license      = { :type => "MIT", :file => "LICENSE.md" }
   s.author       = { "Jesse Farless" => "solidcell@gmail.com" }
-  s.swift_version = "4.0"
+  s.swift_version = "4.2"
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = "9.0"
@@ -16,6 +16,6 @@ Helpful classes and extensions for RxSwift which don't belong in RxSwift core.
   s.source       = { :git => "https://github.com/RxSwiftCommunity/RxSwiftUtilities.git", :tag => "#{s.version}" }
   s.source_files = 'Source/Common/*.swift'
   s.ios.source_files = 'Source/iOS/*.swift'
-  s.dependency   "RxSwift", "~> 4.0"
-  s.dependency   "RxCocoa", "~> 4.0"
+  s.dependency   "RxSwift", "~> 4.4"
+  s.dependency   "RxCocoa", "~> 4.4"
 end

--- a/Source/Common/ActivityIndicator.swift
+++ b/Source/Common/ActivityIndicator.swift
@@ -42,11 +42,11 @@ public class ActivityIndicator : SharedSequenceConvertibleType {
     public typealias SharingStrategy = DriverSharingStrategy
 
     private let _lock = NSRecursiveLock()
-    private let _variable = BehaviorRelay(value: 0)
+    private let _relay = BehaviorRelay(value: 0)
     private let _loading: SharedSequence<SharingStrategy, Bool>
 
     public init() {
-        _loading = _variable.asDriver()
+        _loading = _relay.asDriver()
             .map { $0 > 0 }
             .distinctUntilChanged()
     }
@@ -62,13 +62,13 @@ public class ActivityIndicator : SharedSequenceConvertibleType {
 
     private func increment() {
         _lock.lock()
-        _variable.accept(_variable.value + 1)
+        _relay.accept(_relay.value + 1)
         _lock.unlock()
     }
 
     private func decrement() {
         _lock.lock()
-        _variable.accept(_variable.value - 1)
+        _relay.accept(_relay.value - 1)
         _lock.unlock()
     }
 

--- a/Source/Common/ActivityIndicator.swift
+++ b/Source/Common/ActivityIndicator.swift
@@ -42,7 +42,7 @@ public class ActivityIndicator : SharedSequenceConvertibleType {
     public typealias SharingStrategy = DriverSharingStrategy
 
     private let _lock = NSRecursiveLock()
-    private let _variable = Variable(0)
+    private let _variable = BehaviorRelay(value: 0)
     private let _loading: SharedSequence<SharingStrategy, Bool>
 
     public init() {
@@ -62,13 +62,13 @@ public class ActivityIndicator : SharedSequenceConvertibleType {
 
     private func increment() {
         _lock.lock()
-        _variable.value = _variable.value + 1
+        _variable.accept(_variable.value + 1)
         _lock.unlock()
     }
 
     private func decrement() {
         _lock.lock()
-        _variable.value = _variable.value - 1
+        _variable.accept(_variable.value - 1)
         _lock.unlock()
     }
 


### PR DESCRIPTION
Replace usage of `Variable<Int>` to `BehaviorRelay<Int>`.