### PR TITLE
Add forwardError(to:) operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [master](https://github.com/RxSwiftCommunity/RxSwiftUtilities/tree/master) (Xcode 10 / Swift 4.2 compatible)
 
 * Replace usage of deprecated Variable<Int> for BehaviorRelay<Int>.
-* Add ErrorTracker.
+* Add ObservableConvertibleType.forwardError operator.
 
 ## [2.1.0](https://github.com/RxSwiftCommunity/RxSwiftUtilities/releases/tag/2.1.0) (Xcode 10 / Swift 4.2 compatible)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ## [master](https://github.com/RxSwiftCommunity/RxSwiftUtilities/tree/master) (Xcode 10 / Swift 4.2 compatible)
 
-* nothing *
+* Replace usage of deprecated Variable<Int> for BehaviorRelay<Int>.
+* Add ErrorTracker.
 
 ## [2.1.0](https://github.com/RxSwiftCommunity/RxSwiftUtilities/releases/tag/2.1.0) (Xcode 10 / Swift 4.2 compatible)
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,27 @@ signingIn.asDriver()
     .disposed(by: disposeBag)
 ```
 
+### ErrorTracker
+
+```swift
+let errorTracker = ErrorTracker()
+
+let signedIn = loginButtonTap.withLatestFrom(usernameAndPassword)
+    .flatMapLatest { (username, password) in
+        return API.signup(username, password: password)
+            .trackeError(errorTracker)
+            .catchError({ _ in Observable.never() })
+    }
+}
+
+errorTracker.asDriver()
+    .drive(onNext: { error in
+        // Handling specific/generic errors.
+    })
+    .disposed(by: disposeBag)
+```
+
+
 #### Two-way binding
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ signingIn.asDriver()
     .disposed(by: disposeBag)
 ```
 
-### ErrorTracker
+### ForwardError
 
 ```swift
-let errorTracker = ErrorTracker()
+let errorTracker = PublishRelay<Error>()
 
 let signedIn = loginButtonTap.withLatestFrom(usernameAndPassword)
     .flatMapLatest { (username, password) in
         return API.signup(username, password: password)
-            .trackeError(errorTracker)
+            .forwardError(to: errorTracker)
             .catchError({ _ in Observable.never() })
     }
 }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ errorTracker.asDriver()
     .disposed(by: disposeBag)
 ```
 
-
 #### Two-way binding
 
 ```swift

--- a/RxSwiftUtilities.xcodeproj/project.pbxproj
+++ b/RxSwiftUtilities.xcodeproj/project.pbxproj
@@ -7,10 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		539C0857219D970D00328A60 /* ErrorTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0856219D970D00328A60 /* ErrorTracker.swift */; };
-		539C085A219D9A0600328A60 /* ErrorTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0856219D970D00328A60 /* ErrorTracker.swift */; };
-		539C085B219D9A0600328A60 /* ErrorTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0856219D970D00328A60 /* ErrorTracker.swift */; };
-		539C085C219D9A0700328A60 /* ErrorTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0856219D970D00328A60 /* ErrorTracker.swift */; };
+		539C0857219D970D00328A60 /* ObservableConvertibleType+forwardError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0856219D970D00328A60 /* ObservableConvertibleType+forwardError.swift */; };
+		539C085A219D9A0600328A60 /* ObservableConvertibleType+forwardError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0856219D970D00328A60 /* ObservableConvertibleType+forwardError.swift */; };
+		539C085B219D9A0600328A60 /* ObservableConvertibleType+forwardError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0856219D970D00328A60 /* ObservableConvertibleType+forwardError.swift */; };
+		539C085C219D9A0700328A60 /* ObservableConvertibleType+forwardError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0856219D970D00328A60 /* ObservableConvertibleType+forwardError.swift */; };
 		539C0864219D9B1F00328A60 /* ErrorTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0863219D9B1F00328A60 /* ErrorTrackerTests.swift */; };
 		539C0865219D9B1F00328A60 /* ErrorTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0863219D9B1F00328A60 /* ErrorTrackerTests.swift */; };
 		539C0866219D9B1F00328A60 /* ErrorTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0863219D9B1F00328A60 /* ErrorTrackerTests.swift */; };
@@ -72,7 +72,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		539C0856219D970D00328A60 /* ErrorTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorTracker.swift; sourceTree = "<group>"; };
+		539C0856219D970D00328A60 /* ObservableConvertibleType+forwardError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ObservableConvertibleType+forwardError.swift"; sourceTree = "<group>"; };
 		539C0863219D9B1F00328A60 /* ErrorTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTrackerTests.swift; sourceTree = "<group>"; };
 		880343081DE303160055DA33 /* RxSwiftUtilities.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwiftUtilities.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8803430B1DE303160055DA33 /* RxSwiftUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RxSwiftUtilities.h; sourceTree = "<group>"; };
@@ -284,7 +284,7 @@
 			isa = PBXGroup;
 			children = (
 				8803436A1DE396290055DA33 /* ActivityIndicator.swift */,
-				539C0856219D970D00328A60 /* ErrorTracker.swift */,
+				539C0856219D970D00328A60 /* ObservableConvertibleType+forwardError.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -644,7 +644,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				88EB631C216B2D2E00130C74 /* TwoWayBinding.swift in Sources */,
-				539C0857219D970D00328A60 /* ErrorTracker.swift in Sources */,
+				539C0857219D970D00328A60 /* ObservableConvertibleType+forwardError.swift in Sources */,
 				8803436B1DE396290055DA33 /* ActivityIndicator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -664,7 +664,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				888CC1B91DE48ADF00DAE48A /* ActivityIndicator.swift in Sources */,
-				539C085B219D9A0600328A60 /* ErrorTracker.swift in Sources */,
+				539C085B219D9A0600328A60 /* ObservableConvertibleType+forwardError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -682,7 +682,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				888CC1E41DE48FB300DAE48A /* ActivityIndicator.swift in Sources */,
-				539C085A219D9A0600328A60 /* ErrorTracker.swift in Sources */,
+				539C085A219D9A0600328A60 /* ObservableConvertibleType+forwardError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -700,7 +700,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				88E73C6A1DE4821F00C0D2F6 /* ActivityIndicator.swift in Sources */,
-				539C085C219D9A0700328A60 /* ErrorTracker.swift in Sources */,
+				539C085C219D9A0700328A60 /* ObservableConvertibleType+forwardError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RxSwiftUtilities.xcodeproj/project.pbxproj
+++ b/RxSwiftUtilities.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		539C0857219D970D00328A60 /* ErrorTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0856219D970D00328A60 /* ErrorTracker.swift */; };
+		539C085A219D9A0600328A60 /* ErrorTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0856219D970D00328A60 /* ErrorTracker.swift */; };
+		539C085B219D9A0600328A60 /* ErrorTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0856219D970D00328A60 /* ErrorTracker.swift */; };
+		539C085C219D9A0700328A60 /* ErrorTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0856219D970D00328A60 /* ErrorTracker.swift */; };
+		539C0864219D9B1F00328A60 /* ErrorTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0863219D9B1F00328A60 /* ErrorTrackerTests.swift */; };
+		539C0865219D9B1F00328A60 /* ErrorTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0863219D9B1F00328A60 /* ErrorTrackerTests.swift */; };
+		539C0866219D9B1F00328A60 /* ErrorTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539C0863219D9B1F00328A60 /* ErrorTrackerTests.swift */; };
 		880343121DE303160055DA33 /* RxSwiftUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 880343081DE303160055DA33 /* RxSwiftUtilities.framework */; };
 		880343191DE303160055DA33 /* RxSwiftUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 8803430B1DE303160055DA33 /* RxSwiftUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		880343681DE395A20055DA33 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 880343671DE395A20055DA33 /* RxCocoa.framework */; };
@@ -65,6 +72,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		539C0856219D970D00328A60 /* ErrorTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorTracker.swift; sourceTree = "<group>"; };
+		539C0863219D9B1F00328A60 /* ErrorTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTrackerTests.swift; sourceTree = "<group>"; };
 		880343081DE303160055DA33 /* RxSwiftUtilities.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwiftUtilities.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8803430B1DE303160055DA33 /* RxSwiftUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RxSwiftUtilities.h; sourceTree = "<group>"; };
 		8803430C1DE303160055DA33 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -199,8 +208,9 @@
 			isa = PBXGroup;
 			children = (
 				8803436E1DE397170055DA33 /* ActivityIndicatorTests.swift */,
-				88EB631D216B2E1C00130C74 /* TwoWayBindingTests.swift */,
+				539C0863219D9B1F00328A60 /* ErrorTrackerTests.swift */,
 				880343331DE315B70055DA33 /* Supporting Files */,
+				88EB631D216B2E1C00130C74 /* TwoWayBindingTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -274,6 +284,7 @@
 			isa = PBXGroup;
 			children = (
 				8803436A1DE396290055DA33 /* ActivityIndicator.swift */,
+				539C0856219D970D00328A60 /* ErrorTracker.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -633,6 +644,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				88EB631C216B2D2E00130C74 /* TwoWayBinding.swift in Sources */,
+				539C0857219D970D00328A60 /* ErrorTracker.swift in Sources */,
 				8803436B1DE396290055DA33 /* ActivityIndicator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -641,6 +653,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				539C0864219D9B1F00328A60 /* ErrorTrackerTests.swift in Sources */,
 				88EB631F216B2E2500130C74 /* TwoWayBindingTests.swift in Sources */,
 				8803436F1DE397170055DA33 /* ActivityIndicatorTests.swift in Sources */,
 			);
@@ -651,6 +664,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				888CC1B91DE48ADF00DAE48A /* ActivityIndicator.swift in Sources */,
+				539C085B219D9A0600328A60 /* ErrorTracker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -659,6 +673,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				888CC1BA1DE48AE400DAE48A /* ActivityIndicatorTests.swift in Sources */,
+				539C0866219D9B1F00328A60 /* ErrorTrackerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -667,6 +682,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				888CC1E41DE48FB300DAE48A /* ActivityIndicator.swift in Sources */,
+				539C085A219D9A0600328A60 /* ErrorTracker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -675,6 +691,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				888CC1E51DE48FBA00DAE48A /* ActivityIndicatorTests.swift in Sources */,
+				539C0865219D9B1F00328A60 /* ErrorTrackerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -683,6 +700,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				88E73C6A1DE4821F00C0D2F6 /* ActivityIndicator.swift in Sources */,
+				539C085C219D9A0700328A60 /* ErrorTracker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/Common/ErrorTracker.swift
+++ b/Source/Common/ErrorTracker.swift
@@ -9,13 +9,13 @@ import RxCocoa
 import RxSwift
 
 extension ObservableConvertibleType {
-    public func trackError<T>(_ tracker: T) -> Observable<Self.E> where T: ObserverType, T.E == Error {
+    public func forwardError<T>(to tracker: T) -> Observable<Self.E> where T: ObserverType, T.E == Error {
         return asObservable().do(onError: { error in
             tracker.onNext(error)
         })
     }
 
-    public func trackError<T>(_ tracker: T) -> Observable<Self.E> where T: PublishRelay<Error> {
+    public func forwardError<T>(to tracker: T) -> Observable<Self.E> where T: PublishRelay<Error> {
         return asObservable().do(onError: { error in
             tracker.accept(error)
         })

--- a/Source/Common/ErrorTracker.swift
+++ b/Source/Common/ErrorTracker.swift
@@ -1,0 +1,50 @@
+//
+//  ErrorTracker.swift
+//  Pods-ExampleApp
+//
+//  Created by Rafael Ferreira on 11/14/18.
+//
+
+import RxCocoa
+import RxSwift
+
+/**
+ Enables monitoring of errors's throw in sequence computation.
+ */
+public final class ErrorTracker: SharedSequenceConvertibleType {
+    public typealias E = Error
+    public typealias SharingStrategy = DriverSharingStrategy
+
+    private let _subject = PublishRelay<E>()
+    private let _errors: SharedSequence<SharingStrategy, E>
+
+    // MARK: Initializer
+
+    public init() {
+        _errors = _subject.asDriver(onErrorDriveWith: SharedSequence.empty())
+    }
+
+    // MARK: SharedSequenceConvertibleType conforms
+
+    public func asSharedSequence() -> SharedSequence<SharingStrategy, ErrorTracker.E> {
+        return _errors
+    }
+
+    // MARK: Fileprivate functions
+
+    fileprivate func trackErrorOfObservable<O: ObservableConvertibleType>(_ source: O) -> Observable<O.E> {
+        return source.asObservable().do(onError: { [weak self] error in
+            self?.onError(error: error)
+        })
+    }
+
+    private func onError(error: Error) {
+        _subject.accept(error)
+    }
+}
+
+extension ObservableConvertibleType {
+    public func trackError(_ errorTracker: ErrorTracker) -> Observable<E> {
+        return errorTracker.trackErrorOfObservable(self)
+    }
+}

--- a/Source/Common/ErrorTracker.swift
+++ b/Source/Common/ErrorTracker.swift
@@ -8,43 +8,16 @@
 import RxCocoa
 import RxSwift
 
-/**
- Enables monitoring of errors's throw in sequence computation.
- */
-public final class ErrorTracker: SharedSequenceConvertibleType {
-    public typealias E = Error
-    public typealias SharingStrategy = DriverSharingStrategy
-
-    private let _subject = PublishRelay<E>()
-    private let _errors: SharedSequence<SharingStrategy, E>
-
-    // MARK: Initializer
-
-    public init() {
-        _errors = _subject.asDriver(onErrorDriveWith: SharedSequence.empty())
-    }
-
-    // MARK: SharedSequenceConvertibleType conforms
-
-    public func asSharedSequence() -> SharedSequence<SharingStrategy, ErrorTracker.E> {
-        return _errors
-    }
-
-    // MARK: Fileprivate functions
-
-    fileprivate func trackErrorOfObservable<O: ObservableConvertibleType>(_ source: O) -> Observable<O.E> {
-        return source.asObservable().do(onError: { [weak self] error in
-            self?.onError(error: error)
+extension ObservableConvertibleType {
+    public func trackError<T>(_ tracker: T) -> Observable<Self.E> where T: ObserverType, T.E == Error {
+        return asObservable().do(onError: { error in
+            tracker.onNext(error)
         })
     }
 
-    private func onError(error: Error) {
-        _subject.accept(error)
-    }
-}
-
-extension ObservableConvertibleType {
-    public func trackError(_ errorTracker: ErrorTracker) -> Observable<E> {
-        return errorTracker.trackErrorOfObservable(self)
+    public func trackError<T>(_ tracker: T) -> Observable<Self.E> where T: PublishRelay<Error> {
+        return asObservable().do(onError: { error in
+            tracker.accept(error)
+        })
     }
 }

--- a/Source/Common/ObservableConvertibleType+forwardError.swift
+++ b/Source/Common/ObservableConvertibleType+forwardError.swift
@@ -1,5 +1,5 @@
 //
-//  ErrorTracker.swift
+//  ObservableConvertibleType+forwardError.swift
 //  Pods-ExampleApp
 //
 //  Created by Rafael Ferreira on 11/14/18.

--- a/Tests/ErrorTrackerTests.swift
+++ b/Tests/ErrorTrackerTests.swift
@@ -28,7 +28,7 @@ class ErrorTrackerTests: XCTestCase {
             .subscribe(onNext: { error in value = error })
 
         let _ = Observable<Any>.error(RxError.noElements)
-            .trackError(errorTracker)
+            .forwardError(to: errorTracker)
             .subscribe()
 
         XCTAssertNotNil(value)
@@ -42,7 +42,7 @@ class ErrorTrackerTests: XCTestCase {
             .subscribe(onNext: { error in value = error })
 
         let _ = Observable.just(1)
-            .trackError(errorTracker)
+            .forwardError(to: errorTracker)
             .subscribe()
 
         XCTAssertNil(value)
@@ -64,7 +64,7 @@ class ErrorTrackerTests: XCTestCase {
             .subscribe(onNext: { error in value = error })
 
         let _ = Observable<Any>.error(RxError.noElements)
-            .trackError(errorTracker)
+            .forwardError(to: errorTracker)
             .subscribe()
 
         XCTAssertNotNil(value)
@@ -78,7 +78,7 @@ class ErrorTrackerTests: XCTestCase {
             .subscribe(onNext: { error in value = error })
 
         let _ = Observable.just(1)
-            .trackError(errorTracker)
+            .forwardError(to: errorTracker)
             .subscribe()
 
         XCTAssertNil(value)

--- a/Tests/ErrorTrackerTests.swift
+++ b/Tests/ErrorTrackerTests.swift
@@ -12,16 +12,16 @@ import RxSwiftUtilities
 import XCTest
 
 class ErrorTrackerTests: XCTestCase {
-    func testInitiallyEmitsNothing() {
-        let errorTracker = ErrorTracker()
+    func testInitiallyEmitsNothingForPublishRelay() {
+        let errorTracker = PublishRelay<Error>()
         var isInvoked = false
         let _ = errorTracker.asObservable()
             .subscribe(onNext: { _ in isInvoked = true })
         XCTAssertFalse(isInvoked)
     }
 
-    func testEmitsErrorWhenTrackingASingleObservable() {
-        let errorTracker = ErrorTracker()
+    func testEmitsErrorWhenTrackingASingleObservableForPublishRelay() {
+        let errorTracker = PublishRelay<Error>()
         var value: Error? = nil
 
         let _ = errorTracker.asObservable()
@@ -34,8 +34,44 @@ class ErrorTrackerTests: XCTestCase {
         XCTAssertNotNil(value)
     }
 
-    func testEmitsNothingWhenTrackingASingleObservable() {
-        let errorTracker = ErrorTracker()
+    func testEmitsNothingWhenTrackingASingleObservableForPublishRelay() {
+        let errorTracker = PublishRelay<Error>()
+        var value: Error? = nil
+
+        let _ = errorTracker.asObservable()
+            .subscribe(onNext: { error in value = error })
+
+        let _ = Observable.just(1)
+            .trackError(errorTracker)
+            .subscribe()
+
+        XCTAssertNil(value)
+    }
+
+    func testInitiallyEmitsNothingForPublishSubject() {
+        let errorTracker = PublishSubject<Error>()
+        var isInvoked = false
+        let _ = errorTracker.asObservable()
+            .subscribe(onNext: { _ in isInvoked = true })
+        XCTAssertFalse(isInvoked)
+    }
+
+    func testEmitsErrorWhenTrackingASingleObservableForPublishSubject() {
+        let errorTracker = PublishSubject<Error>()
+        var value: Error? = nil
+
+        let _ = errorTracker.asObservable()
+            .subscribe(onNext: { error in value = error })
+
+        let _ = Observable<Any>.error(RxError.noElements)
+            .trackError(errorTracker)
+            .subscribe()
+
+        XCTAssertNotNil(value)
+    }
+
+    func testEmitsNothingWhenTrackingASingleObservableForPublishSubject() {
+        let errorTracker = PublishSubject<Error>()
         var value: Error? = nil
 
         let _ = errorTracker.asObservable()

--- a/Tests/ErrorTrackerTests.swift
+++ b/Tests/ErrorTrackerTests.swift
@@ -1,0 +1,50 @@
+//
+//  ErrorTrackerTests.swift
+//  RxSwiftUtilities
+//
+//  Created by Rafael Ferreira on 11/15/18.
+//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//
+
+import RxCocoa
+import RxSwift
+import RxSwiftUtilities
+import XCTest
+
+class ErrorTrackerTests: XCTestCase {
+    func testInitiallyEmitsNothing() {
+        let errorTracker = ErrorTracker()
+        var isInvoked = false
+        let _ = errorTracker.asObservable()
+            .subscribe(onNext: { _ in isInvoked = true })
+        XCTAssertFalse(isInvoked)
+    }
+
+    func testEmitsErrorWhenTrackingASingleObservable() {
+        let errorTracker = ErrorTracker()
+        var value: Error? = nil
+
+        let _ = errorTracker.asObservable()
+            .subscribe(onNext: { error in value = error })
+
+        let _ = Observable<Any>.error(RxError.noElements)
+            .trackError(errorTracker)
+            .subscribe()
+
+        XCTAssertNotNil(value)
+    }
+
+    func testEmitsNothingWhenTrackingASingleObservable() {
+        let errorTracker = ErrorTracker()
+        var value: Error? = nil
+
+        let _ = errorTracker.asObservable()
+            .subscribe(onNext: { error in value = error })
+
+        let _ = Observable.just(1)
+            .trackError(errorTracker)
+            .subscribe()
+
+        XCTAssertNil(value)
+    }
+}


### PR DESCRIPTION
When I'm working with `Observable`, and have the following situation:
I have a trigger (button tap, for example) and always this trigger is called a API request is made:

```swift
let signedIn = loginButtonTap.withLatestFrom(usernameAndPassword)
    .flatMap { (username, password) in
        return API.signup(username, password: password)
    }
}
```

When an error is throw in `API.signup` call my sequence is lost, but in real case I didn't want it, so a solution for that is `ErrorTracker`, that's a `PublishRelay` wrapper that observe errors in a given sequence and proxy all error for it:

```swift
let errorTracker = ErrorTracker()

let signedIn = loginButtonTap.withLatestFrom(usernameAndPassword)
    .flatMap { (username, password) in
        return API.signup(username, password: password)
            .trackeError(errorTracker)
            .catchError({ _ in Observable.never() })
    }
}

errorTracker.asDriver()
    .drive(onNext: { error in
        // Handling specific/generic errors.
    })
    .disposed(by: disposeBag)
```

The `catchError` just avoid an unexpected end our sequence.

For while this catchError is made by the user, but can it be a part of ErrorTracker.

What do you guys think about it? @RxSwiftCommunity/contributors 