### PR TITLE
Hotfix Carthage versioning for RxSwift 4.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.2
+osx_image: xcode10.1
 before_install:
   - carthage bootstrap --no-use-binaries --platform ios
 script: xcodebuild clean build test -scheme 'RxSwiftUtilities iOS' -destination "platform=iOS Simulator,name=iPhone 6S" -enableCodeCoverage YES

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" ~> 4.4.0
+github "ReactiveX/RxSwift" ~> 4.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" ~> 4.0
+github "ReactiveX/RxSwift" ~> 4.4.0

--- a/ExampleApp/Podfile.lock
+++ b/ExampleApp/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - RxSwift (~> 4.0)
   - RxSwift (4.4.0):
     - RxAtomic (~> 4.4)
-  - RxSwiftUtilities (2.1.0):
+  - RxSwiftUtilities (2.2.0):
     - RxCocoa (~> 4.4)
     - RxSwift (~> 4.4)
 
@@ -25,8 +25,8 @@ SPEC CHECKSUMS:
   RxAtomic: eacf60db868c96bfd63320e28619fe29c179656f
   RxCocoa: df63ebf7b9a70d6b4eeea407ed5dd4efc8979749
   RxSwift: 5976ecd04fc2fefd648827c23de5e11157faa973
-  RxSwiftUtilities: 01034c5ba9ea6b3910458b46f60eff9eb66103f9
+  RxSwiftUtilities: 249c69eca4dfcf7a75af1d4c6d530e959ec8b5ff
 
 PODFILE CHECKSUM: 76bf4791be77375ab3f65b32b122237d1e9eaf79
 
-COCOAPODS: 1.6.0.beta.1
+COCOAPODS: 1.6.0.beta.2

--- a/RxSwiftUtilities.podspec
+++ b/RxSwiftUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RxSwiftUtilities"
-  s.version      = "2.1.0"
+  s.version      = "2.2.0"
   s.summary      = "Helpful classes and extensions for RxSwift"
   s.description  = <<-DESC
 Helpful classes and extensions for RxSwift which don't belong in RxSwift core.

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>2.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
I'm facing rebuilding of all my Rx dependencies because Cartfile was pointing to 4.0.
And the latest version of RxSwift is 4.4.0
Anyone can help with reviewing it and generating a new .zip for GitHub Releases?
@RxSwiftCommunity/contributors 